### PR TITLE
fix: Update Changesets config to remove deleted demo packages

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -3,7 +3,7 @@
 	"changelog": [
 		"@changesets/changelog-github",
 		{
-			"repo": "ascorbic/library-template"
+			"repo": "ascorbic/process-ancestry"
 		}
 	],
 	"commit": false,
@@ -12,7 +12,5 @@
 	"access": "public",
 	"baseBranch": "main",
 	"updateInternalDependencies": "patch",
-	"ignore": [
-		"@demo/*"
-	]
+	"ignore": []
 }


### PR DESCRIPTION
## Summary

This PR fixes the Changesets validation error that's occurring in the release workflow.

## Problem

The release workflow was failing with:


## Root Cause

The  still had  in the ignore list, but we deleted the demos directory in the previous PR. It also had outdated repository references.

## Changes Made

- **Removed  from ignore list** - since demos directory no longer exists
- **Updated repo reference** - from  to 
- **Cleared ignore array** - no packages need to be ignored now

## Impact

This fixes the release workflow ValidationError and allows Changesets to work correctly for publishing the process-ancestry package.

🤖 Generated with [Claude Code](https://claude.ai/code)