### PR TITLE
fix(windows): take a single process snapshot instead of spawning per-ancestor

### DIFF
--- a/.changeset/windows-snapshot-ancestry.md
+++ b/.changeset/windows-snapshot-ancestry.md
@@ -1,0 +1,11 @@
+---
+"process-ancestry": minor
+---
+
+Speed up Windows process ancestry lookups dramatically.
+
+Previously, getting the ancestry chain on Windows spawned one `wmic` subprocess per ancestor. `wmic` startup is slow and the command itself is deprecated (removed by default in Windows 11 24H2 and Windows Server 2025), which made deep trees painful and brittle on modern hosts.
+
+The Windows path now takes a single PowerShell snapshot of every running process via `Get-CimInstance Win32_Process`, builds an in-memory pid -> parent map, and walks the chain locally. That collapses N subprocess spawns into one. PowerShell Core (`pwsh`) is preferred when available; legacy Windows PowerShell is used as a fallback. If PowerShell is somehow unavailable, `wmic` is still tried as a last-resort fallback, but only ever in a single batched call (no per-ancestor invocations).
+
+No public API changes.

--- a/packages/process-ancestry/src/lib/windows.ts
+++ b/packages/process-ancestry/src/lib/windows.ts
@@ -1,79 +1,228 @@
-import { execSync } from "node:child_process";
+import { execFileSync, execSync } from "node:child_process";
 import type { ProcessInfo } from "../types";
 
-function getProcessInfo(pid: number): ProcessInfo | null {
+/**
+ * A snapshot of every process on the system, keyed by PID. Building one of
+ * these requires a single subprocess invocation; walking the ancestry chain
+ * after that is pure in-memory work.
+ *
+ * The previous implementation called `wmic` once per ancestor, which on
+ * Windows could cost hundreds of milliseconds per hop. Building one snapshot
+ * is dramatically faster, and `wmic` is deprecated (removed by default in
+ * recent Windows 11 / Server 2025 builds), so PowerShell + CIM is now the
+ * primary path.
+ */
+export type ProcessSnapshot = Map<number, { ppid: number; command?: string }>;
+
+interface RawProcessRow {
+  ProcessId?: number | string | null;
+  ParentProcessId?: number | string | null;
+  CommandLine?: string | null;
+}
+
+function parsePid(value: unknown): number | null {
+  if (typeof value === "number" && Number.isInteger(value) && value >= 0) {
+    return value;
+  }
+  if (typeof value === "string") {
+    const parsed = parseInt(value.trim(), 10);
+    if (!isNaN(parsed) && parsed >= 0) return parsed;
+  }
+  return null;
+}
+
+/**
+ * Build a {@link ProcessSnapshot} from already-parsed rows. Exposed for tests.
+ *
+ * @internal
+ */
+export function snapshotFromRows(rows: RawProcessRow[]): ProcessSnapshot {
+  const snapshot: ProcessSnapshot = new Map();
+  for (const row of rows) {
+    const pid = parsePid(row.ProcessId);
+    const ppid = parsePid(row.ParentProcessId);
+    if (pid === null || ppid === null) continue;
+    const command =
+      typeof row.CommandLine === "string" && row.CommandLine.trim()
+        ? row.CommandLine.trim()
+        : undefined;
+    snapshot.set(pid, { ppid, command });
+  }
+  return snapshot;
+}
+
+/**
+ * Try to obtain a process snapshot via PowerShell + CIM. This is the modern,
+ * supported path on Windows 10/11 and Windows Server 2016+.
+ *
+ * We prefer `pwsh` (PowerShell Core) when available because it has a faster
+ * cold start than legacy `powershell.exe`, and fall back to `powershell` if
+ * `pwsh` is not on PATH.
+ */
+function snapshotViaPowerShell(): ProcessSnapshot | null {
+  // Output an array of objects, even when only one process matches, so JSON
+  // parsing is consistent regardless of process count. `-Compress` keeps the
+  // payload small for very large process tables.
+  const script =
+    "Get-CimInstance Win32_Process | " +
+    "Select-Object ProcessId,ParentProcessId,CommandLine | " +
+    "ConvertTo-Json -Compress -AsArray";
+
+  const args = [
+    "-NoProfile",
+    "-NonInteractive",
+    "-ExecutionPolicy",
+    "Bypass",
+    "-Command",
+    script,
+  ];
+
+  for (const exe of ["pwsh.exe", "powershell.exe"]) {
+    try {
+      const output = execFileSync(exe, args, {
+        encoding: "utf8",
+        timeout: 10000,
+        windowsHide: true,
+        stdio: ["ignore", "pipe", "ignore"],
+      }).trim();
+
+      if (!output) continue;
+
+      const parsed: unknown = JSON.parse(output);
+      const rows: RawProcessRow[] = Array.isArray(parsed)
+        ? (parsed as RawProcessRow[])
+        : [parsed as RawProcessRow];
+      return snapshotFromRows(rows);
+    } catch {
+      // Try the next executable, then fall through to the wmic fallback.
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Parse the CSV output from
+ * `wmic process get ProcessId,ParentProcessId,CommandLine /format:csv`.
+ *
+ * wmic emits columns alphabetically, so the row layout is:
+ *   Node,CommandLine,ParentProcessId,ProcessId
+ *
+ * `CommandLine` may itself contain commas. We rely on the fact that the two
+ * trailing columns are numeric and parse each row from the end.
+ *
+ * @internal
+ */
+export function parseWmicCsv(output: string): RawProcessRow[] {
+  const rows: RawProcessRow[] = [];
+  for (const rawLine of output.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith("Node,")) continue;
+
+    const fields = line.split(",");
+    if (fields.length < 4) continue;
+
+    const pid = fields[fields.length - 1];
+    const ppid = fields[fields.length - 2];
+    const commandLine = fields
+      .slice(1, fields.length - 2)
+      .join(",")
+      .trim();
+
+    rows.push({
+      ProcessId: pid,
+      ParentProcessId: ppid,
+      CommandLine: commandLine || null,
+    });
+
+    // Cap memory on hosts with very large process tables.
+    if (rows.length > 50000) break;
+  }
+  return rows;
+}
+
+/**
+ * Legacy `wmic` fallback. `wmic` is deprecated on modern Windows and missing
+ * by default on Windows 11 24H2 / Server 2025+, so this path is best-effort.
+ *
+ * Critically, we still issue ONE call (no `where` filter) and parse the full
+ * table client-side, rather than spawning `wmic` per ancestor.
+ */
+function snapshotViaWmic(): ProcessSnapshot | null {
   try {
     const output = execSync(
-      `wmic process where (ProcessId=${pid}) get ProcessId,ParentProcessId,CommandLine /format:csv`,
-      { 
+      "wmic process get ProcessId,ParentProcessId,CommandLine /format:csv",
+      {
         encoding: "utf8",
-        timeout: 10000, // 10 second timeout (wmic can be slower)
+        timeout: 15000,
+        windowsHide: true,
+        stdio: ["ignore", "pipe", "ignore"],
       },
     );
-    
-    if (!output) {
-      return null;
-    }
-    
-    const lines = output
-      .split("\n")
-      .filter((line) => line.trim() && !line.startsWith("Node"));
-    const fields = lines.pop()?.split(",");
 
-    if (!fields || fields.length < 4) return null;
-
-    const [_node, commandLine, parentPid, thisPid] = fields;
-    
-    // Validate parsed values
-    const parsedPid = thisPid ? parseInt(thisPid.trim(), 10) : NaN;
-    const parsedPpid = parentPid ? parseInt(parentPid.trim(), 10) : NaN;
-    
-    if (isNaN(parsedPid) || isNaN(parsedPpid)) {
-      return null;
-    }
-    
-    return {
-      pid: parsedPid,
-      ppid: parsedPpid,
-      command: commandLine?.trim() || undefined,
-    };
-  } catch (error) {
-    // Log error for debugging but don't throw
-    if (error instanceof Error && error.message.includes("timeout")) {
-      console.warn(`Process lookup timed out for PID ${pid}`);
-    }
+    if (!output) return null;
+    const rows = parseWmicCsv(output);
+    return rows.length === 0 ? null : snapshotFromRows(rows);
+  } catch {
     return null;
   }
+}
+
+function getProcessSnapshot(): ProcessSnapshot {
+  return snapshotViaPowerShell() ?? snapshotViaWmic() ?? new Map();
+}
+
+/**
+ * Walk a pre-built {@link ProcessSnapshot} to recover an ancestry chain. Pure
+ * function, exposed for tests.
+ *
+ * @internal
+ */
+export function walkSnapshot(
+  snapshot: ProcessSnapshot,
+  startPid: number,
+): Array<ProcessInfo> {
+  if (snapshot.size === 0) return [];
+
+  const result: ProcessInfo[] = [];
+  const visited = new Set<number>();
+  let currentPid: number | undefined = startPid;
+  let maxDepth = 1000;
+
+  while (currentPid && maxDepth > 0) {
+    if (visited.has(currentPid)) {
+      console.warn(`Detected cycle in process tree at PID ${currentPid}`);
+      break;
+    }
+    visited.add(currentPid);
+
+    const entry = snapshot.get(currentPid);
+    // PID 0 (System Idle) and PID 4 (System) are the terminal cases on
+    // Windows. Stop traversal when we hit them, matching the previous
+    // implementation's behaviour.
+    if (!entry || entry.ppid === 0 || entry.ppid === 4) break;
+
+    result.push({
+      pid: currentPid,
+      ppid: entry.ppid,
+      command: entry.command,
+    });
+
+    currentPid = entry.ppid;
+    maxDepth--;
+  }
+
+  if (maxDepth === 0) {
+    console.warn(
+      `Reached maximum depth limit while traversing process tree from PID ${startPid}`,
+    );
+  }
+
+  return result;
 }
 
 export default function getAncestryWindows(
   startPid: number,
 ): Array<ProcessInfo> {
-  const result: ProcessInfo[] = [];
-  const visited = new Set<number>();
-  let currentPid: number | undefined = startPid;
-  let maxDepth = 1000; // Prevent infinite loops
-
-  while (currentPid && maxDepth > 0) {
-    // Check for cycles
-    if (visited.has(currentPid)) {
-      console.warn(`Detected cycle in process tree at PID ${currentPid}`);
-      break;
-    }
-    
-    visited.add(currentPid);
-    
-    const info = getProcessInfo(currentPid);
-    if (!info || info.ppid === 0 || info.ppid === 4) break;
-    
-    result.push(info);
-    currentPid = info.ppid;
-    maxDepth--;
-  }
-
-  if (maxDepth === 0) {
-    console.warn(`Reached maximum depth limit while traversing process tree from PID ${startPid}`);
-  }
-
-  return result;
+  return walkSnapshot(getProcessSnapshot(), startPid);
 }

--- a/packages/process-ancestry/test/hello.test.ts
+++ b/packages/process-ancestry/test/hello.test.ts
@@ -1,21 +1,30 @@
 import { describe, it, expect } from "vitest";
 import { getProcessAncestry } from "../src/index.js";
 
-describe("getProcessAncestry", () => {
-  it("should return process ancestry for current process", () => {
-    const ancestry = getProcessAncestry();
-    console.log("Ancestry:", ancestry);
-    expect(Array.isArray(ancestry)).toBe(true);
+// These tests spawn a real subprocess (`ps` on Unix, `pwsh`/`wmic` on Windows).
+// PowerShell cold start in particular can take several seconds on fresh CI
+// runners, so we use a generous timeout rather than the 5s vitest default.
+const SUBPROCESS_TIMEOUT_MS = 30_000;
 
-    // Should have at least one parent process
-    if (ancestry.length > 0) {
-      const first = ancestry[0]!;
-      expect(first).toHaveProperty("pid");
-      expect(first).toHaveProperty("ppid");
-      expect(typeof first.pid).toBe("number");
-      expect(typeof first.ppid).toBe("number");
-    }
-  });
+describe("getProcessAncestry", () => {
+  it(
+    "should return process ancestry for current process",
+    () => {
+      const ancestry = getProcessAncestry();
+      console.log("Ancestry:", ancestry);
+      expect(Array.isArray(ancestry)).toBe(true);
+
+      // Should have at least one parent process
+      if (ancestry.length > 0) {
+        const first = ancestry[0]!;
+        expect(first).toHaveProperty("pid");
+        expect(first).toHaveProperty("ppid");
+        expect(typeof first.pid).toBe("number");
+        expect(typeof first.ppid).toBe("number");
+      }
+    },
+    SUBPROCESS_TIMEOUT_MS,
+  );
 
   it("should validate PID parameter", () => {
     expect(() => getProcessAncestry(-1)).toThrow(
@@ -35,18 +44,26 @@ describe("getProcessAncestry", () => {
     );
   });
 
-  it("should handle non-existent PID gracefully", () => {
-    // Use a very high PID that likely doesn't exist
-    const ancestry = getProcessAncestry(999999);
-    expect(Array.isArray(ancestry)).toBe(true);
-    // Should return empty array for non-existent process
-    expect(ancestry.length).toBe(0);
-  });
+  it(
+    "should handle non-existent PID gracefully",
+    () => {
+      // Use a very high PID that likely doesn't exist
+      const ancestry = getProcessAncestry(999999);
+      expect(Array.isArray(ancestry)).toBe(true);
+      // Should return empty array for non-existent process
+      expect(ancestry.length).toBe(0);
+    },
+    SUBPROCESS_TIMEOUT_MS,
+  );
 
-  it("should handle PID 1 (init process)", () => {
-    const ancestry = getProcessAncestry(1);
-    expect(Array.isArray(ancestry)).toBe(true);
-    // Init process should have no parents or very few
-    expect(ancestry.length).toBeLessThanOrEqual(1);
-  });
+  it(
+    "should handle PID 1 (init process)",
+    () => {
+      const ancestry = getProcessAncestry(1);
+      expect(Array.isArray(ancestry)).toBe(true);
+      // Init process should have no parents or very few
+      expect(ancestry.length).toBeLessThanOrEqual(1);
+    },
+    SUBPROCESS_TIMEOUT_MS,
+  );
 });

--- a/packages/process-ancestry/test/windows.test.ts
+++ b/packages/process-ancestry/test/windows.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseWmicCsv,
+  snapshotFromRows,
+  walkSnapshot,
+  type ProcessSnapshot,
+} from "../src/lib/windows.js";
+
+describe("snapshotFromRows", () => {
+  it("builds a snapshot from typical PowerShell rows", () => {
+    const snapshot = snapshotFromRows([
+      { ProcessId: 100, ParentProcessId: 4, CommandLine: "wininit.exe" },
+      {
+        ProcessId: 200,
+        ParentProcessId: 100,
+        CommandLine: "C\\System32\\services.exe",
+      },
+      { ProcessId: 300, ParentProcessId: 200, CommandLine: null },
+    ]);
+
+    expect(snapshot.size).toBe(3);
+    expect(snapshot.get(100)).toEqual({ ppid: 4, command: "wininit.exe" });
+    expect(snapshot.get(200)).toEqual({
+      ppid: 100,
+      command: "C\\System32\\services.exe",
+    });
+    expect(snapshot.get(300)).toEqual({ ppid: 200, command: undefined });
+  });
+
+  it("accepts string PIDs (wmic delivers them as strings)", () => {
+    const snapshot = snapshotFromRows([
+      { ProcessId: "1234", ParentProcessId: "5678", CommandLine: "node" },
+    ]);
+    expect(snapshot.get(1234)).toEqual({ ppid: 5678, command: "node" });
+  });
+
+  it("ignores rows missing required fields", () => {
+    const snapshot = snapshotFromRows([
+      { ProcessId: null, ParentProcessId: 1, CommandLine: "x" },
+      { ProcessId: 1, ParentProcessId: undefined, CommandLine: "x" },
+      { ProcessId: 5, ParentProcessId: 1, CommandLine: "x" },
+    ]);
+    expect(Array.from(snapshot.keys())).toEqual([5]);
+  });
+
+  it("normalizes whitespace-only command lines to undefined", () => {
+    const snapshot = snapshotFromRows([
+      { ProcessId: 1, ParentProcessId: 0, CommandLine: "   " },
+    ]);
+    expect(snapshot.get(1)?.command).toBeUndefined();
+  });
+});
+
+describe("parseWmicCsv", () => {
+  it("parses standard CSV output", () => {
+    const csv = [
+      "",
+      "Node,CommandLine,ParentProcessId,ProcessId",
+      "WIN-HOST,wininit.exe,300,400",
+      "WIN-HOST,C:\\Windows\\System32\\services.exe,400,500",
+      "",
+    ].join("\r\n");
+
+    const rows = parseWmicCsv(csv);
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toEqual({
+      ProcessId: "400",
+      ParentProcessId: "300",
+      CommandLine: "wininit.exe",
+    });
+    expect(rows[1]).toEqual({
+      ProcessId: "500",
+      ParentProcessId: "400",
+      CommandLine: "C:\\Windows\\System32\\services.exe",
+    });
+  });
+
+  it("recovers command lines that themselves contain commas", () => {
+    const csv = [
+      "Node,CommandLine,ParentProcessId,ProcessId",
+      'WIN-HOST,node.exe --flag=a,b,c,1000,2000',
+    ].join("\r\n");
+
+    const rows = parseWmicCsv(csv);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toEqual({
+      ProcessId: "2000",
+      ParentProcessId: "1000",
+      CommandLine: "node.exe --flag=a,b,c",
+    });
+  });
+
+  it("treats an empty command line as null", () => {
+    const csv = [
+      "Node,CommandLine,ParentProcessId,ProcessId",
+      "WIN-HOST,,1,2",
+    ].join("\r\n");
+
+    const rows = parseWmicCsv(csv);
+    expect(rows[0]?.CommandLine).toBeNull();
+  });
+
+  it("skips malformed rows without throwing", () => {
+    const csv = [
+      "Node,CommandLine,ParentProcessId,ProcessId",
+      "too,few",
+      "WIN-HOST,cmd.exe,1,2",
+    ].join("\n");
+
+    const rows = parseWmicCsv(csv);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.ProcessId).toBe("2");
+  });
+});
+
+describe("walkSnapshot", () => {
+  function makeSnapshot(
+    entries: Array<[number, number, string?]>,
+  ): ProcessSnapshot {
+    const map: ProcessSnapshot = new Map();
+    for (const [pid, ppid, command] of entries) {
+      map.set(pid, { ppid, command });
+    }
+    return map;
+  }
+
+  it("returns an empty array when the snapshot is empty", () => {
+    expect(walkSnapshot(new Map(), 1234)).toEqual([]);
+  });
+
+  it("walks parent links until reaching System (ppid 4)", () => {
+    const snapshot = makeSnapshot([
+      [1000, 800, "node script.js"],
+      [800, 400, "cmd.exe"],
+      [400, 4, "wininit.exe"],
+    ]);
+
+    const ancestry = walkSnapshot(snapshot, 1000);
+    expect(ancestry).toEqual([
+      { pid: 1000, ppid: 800, command: "node script.js" },
+      { pid: 800, ppid: 400, command: "cmd.exe" },
+    ]);
+  });
+
+  it("stops at ppid 0 (System Idle) too", () => {
+    const snapshot = makeSnapshot([
+      [200, 100, "a"],
+      [100, 0, "root"],
+    ]);
+
+    const ancestry = walkSnapshot(snapshot, 200);
+    expect(ancestry).toEqual([{ pid: 200, ppid: 100, command: "a" }]);
+  });
+
+  it("returns an empty array when the start PID isn't in the snapshot", () => {
+    const snapshot = makeSnapshot([[100, 4, "foo"]]);
+    expect(walkSnapshot(snapshot, 999)).toEqual([]);
+  });
+
+  it("breaks out of cycles instead of looping forever", () => {
+    const snapshot = makeSnapshot([
+      [1, 2, "one"],
+      [2, 1, "two"], // cycle
+    ]);
+
+    const ancestry = walkSnapshot(snapshot, 1);
+    // Should record one hop, then bail when the cycle is detected.
+    expect(ancestry.length).toBeGreaterThan(0);
+    expect(ancestry.length).toBeLessThanOrEqual(2);
+  });
+
+  it("preserves command strings on each ancestor", () => {
+    const snapshot = makeSnapshot([
+      [10, 20, "cmd-a"],
+      [20, 30, "cmd-b"],
+      [30, 4, "wininit.exe"],
+    ]);
+
+    const ancestry = walkSnapshot(snapshot, 10);
+    expect(ancestry.map((a) => a.command)).toEqual([
+      "cmd-a",
+      "cmd-b",
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

Replace the per-ancestor `wmic` spawn loop on Windows with a single PowerShell `Get-CimInstance` snapshot, then walk the parent chain in memory. One subprocess for the whole tree instead of one per hop.

## Why

The previous implementation called `wmic process where (ProcessId=N) ...` once per ancestor. Two problems:

1. **Perf.** `wmic` cold start is hundreds of ms. A typical 4-5 deep tree took 1-2.5s+.
2. **Deprecation.** `wmic` is gone by default in Windows 11 24H2 and Windows Server 2025. The current code silently fails on those hosts.

`am-i-vibing` exposed this when fanning out the detector across providers; the fix in [ascorbic/am-i-vibing#72](https://github.com/ascorbic/am-i-vibing/pull/72) reduces how often we walk the tree at all, and this PR makes the walk itself cheap when we do.

## Approach

1. **One** PowerShell call returns the full process table as JSON.
2. Build a `Map<pid, { ppid, command }>`.
3. Walk the map locally with the same termination conditions as before (stop at ppid 0 / 4, cycle guard, max depth).

`pwsh.exe` (PowerShell Core) is tried first because its cold start is meaningfully faster than legacy `powershell.exe`. We fall back to legacy PowerShell, and only as a last resort to `wmic` (still in a single batched call, never per ancestor).

## Tests

Pure parser and walker logic is now unit-tested:

- `snapshotFromRows` covers numeric / string PID handling and missing-field rows.
- `parseWmicCsv` covers normal output, command lines containing commas, empty command lines, malformed rows.
- `walkSnapshot` covers normal walks, `ppid 0` / `ppid 4` termination, missing start PID, cycle guard, command propagation.

The actual subprocess paths still need a Windows runner to exercise; CI's `windows-latest` job covers that.

## Compatibility

No public API changes. Output shape is identical to the previous implementation.

## Replaces #11

Closes #11. PR #11 swapped `wmic` for per-call PowerShell, which addresses the deprecation but not the per-ancestor spawn cost (PowerShell startup is comparable to or slower than `wmic`). The snapshot model addresses both.